### PR TITLE
Feature/sht 5366 dynamically initialize posthog

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:posthog_flutter/posthog_flutter.dart';
+import 'package:posthog_flutter_example/constants.dart';
 
 void main() {
   runApp(const MyApp());
@@ -39,6 +40,24 @@ class _MyAppState extends State<MyApp> {
             child: Center(
               child: Column(
                 children: [
+                  const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Text(
+                      "Configure",
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  const Divider(),
+                  ElevatedButton(
+                    onPressed: () async {
+                      await _posthogFlutterPlugin.configure(
+                        apiKey: apiKey,
+                        host: host,
+                        debug: true,
+                      );
+                    },
+                    child: const Text("Configure"),
+                  ),
                   const Padding(
                     padding: EdgeInsets.all(8.0),
                     child: Text(

--- a/lib/src/posthog.dart
+++ b/lib/src/posthog.dart
@@ -12,6 +12,17 @@ class Posthog {
 
   String? _currentScreen;
 
+  Future<void> configure({
+    required String apiKey,
+    required String host,
+    bool debug = false,
+    bool trackApplicationLifecycleEvents = false,
+  }) {
+    return _posthog.configure(apiKey, host,
+        debug: debug,
+        trackApplicationLifecycleEvents: trackApplicationLifecycleEvents);
+  }
+
   Future<void> identify({
     required String userId,
     Map<String, Object>? userProperties,

--- a/lib/src/posthog_flutter_io.dart
+++ b/lib/src/posthog_flutter_io.dart
@@ -9,6 +9,22 @@ class PosthogFlutterIO extends PosthogFlutterPlatformInterface {
   final _methodChannel = const MethodChannel('posthog_flutter');
 
   @override
+  Future<void> configure(String apiKey, String host,
+      {bool debug = false,
+      bool trackApplicationLifecycleEvents = false}) async {
+    try {
+      await _methodChannel.invokeMethod('configure', {
+        'apiKey': apiKey,
+        'host': host,
+        'debug': debug,
+        'trackApplicationLifecycleEvents': trackApplicationLifecycleEvents,
+      });
+    } on PlatformException catch (e) {
+      _printIfDebug('Exception on configure: $e');
+    }
+  }
+
+  @override
   Future<void> identify({
     required String userId,
     Map<String, Object>? userProperties,

--- a/lib/src/posthog_flutter_platform_interface.dart
+++ b/lib/src/posthog_flutter_platform_interface.dart
@@ -23,6 +23,11 @@ abstract class PosthogFlutterPlatformInterface extends PlatformInterface {
     _instance = instance;
   }
 
+  Future<void> configure(String apiKey, String host,
+      {bool debug = false, bool trackApplicationLifecycleEvents = false}) {
+    throw UnimplementedError('configure() has not been implemented.');
+  }
+
   Future<void> identify(
       {required String userId,
       Map<String, Object>? userProperties,


### PR DESCRIPTION
## :bulb: Motivation and Context
Posthog initialization can only be done natively from android manifest and info.plist. However, there are cases where user want to configure dynamically from the dart side.

A good example is loading the posthog api key and host from some 3rd party(say api or firebase remote config) and then setting up posthog.

The current setup does not allow

This PR aims at  solving the above described issue.


## :green_heart: How did you test it?
With the example code, on an emulator.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
